### PR TITLE
DEXXXX: Search Excluded IDs

### DIFF
--- a/lib/jekyll-cloudsearch/client.rb
+++ b/lib/jekyll-cloudsearch/client.rb
@@ -2,11 +2,11 @@ module Jekyll
   module Cloudsearch
     class Client
 
-      attr_accessor :filename, :site, :docs, :search_excluded_docs
+      attr_accessor :filename, :site, :docs, :search_excluded_ids
 
       def initialize
         @docs = []
-        @search_excluded_docs = []
+        @search_excluded_ids = []
       end
 
       def run
@@ -31,9 +31,7 @@ module Jekyll
 
       def add_document(doc)
         if doc.data.dig('search_excluded')
-          @search_excluded_docs.push({
-            id: "CF_#{ENV['CONTENTFUL_SPACE_ID']}_#{doc.data.dig('id')}"
-          })
+          @search_excluded_ids.push("CF_#{ENV['CONTENTFUL_SPACE_ID']}_#{doc.data.dig('id')}")
         else
           @docs.push({
             id: "CF_#{ENV['CONTENTFUL_SPACE_ID']}_#{doc.data.dig('id')}",
@@ -49,7 +47,7 @@ module Jekyll
       end
 
       def deletions
-        (stale_ids + unpublished_ids + @search_excluded_docs).collect do |id|
+        (stale_ids + unpublished_ids + @search_excluded_ids).collect do |id|
           { id: id, type: 'delete' }
         end
       end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -59,12 +59,12 @@ describe Jekyll::Cloudsearch::Client do
     expect(@client.docs.first[:fields].keys).to match_array([:title, :content, :link, :type])
   end
 
-  it 'should push search excluded documents onto the excluded docs array' do
+  it 'should push search excluded ids onto the excluded ids array' do
     doc = @site.collections['posts'].docs.select{ |item| item.data.dig('search_excluded') == true }.first
     doc_id = "CF_#{ENV['CONTENTFUL_SPACE_ID']}_#{doc.data.dig('id')}"
     @client.add_document(doc)
     expect(@client.docs.include?(doc)).to eq(false)
-    expect(@client.search_excluded_docs.include?("id": doc_id)).to eq(true)
+    expect(@client.search_excluded_ids.include?(doc_id)).to eq(true)
   end
 
   it 'should write and upload' do


### PR DESCRIPTION
Error: `jekyll 3.7.4 | Error: { ["The value of id cannot be a JSON array or object"] }`

Jekyll was having some issues because I was creating a doc object with an `id` key for each search excluded page. Changed this to work the same as stale and unpublished (an array with ids).