### PR TITLE
DE6041 Search Results

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-cloudsearch (0.0.4)
+    jekyll-cloudsearch (0.0.5)
       aws-sdk-cloudsearchdomain
       contentful-management (~> 1.10.1)
       jekyll
@@ -13,11 +13,11 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.105.0)
-    aws-sdk-cloudsearchdomain (1.3.0)
+    aws-partitions (1.110.0)
+    aws-sdk-cloudsearchdomain (1.5.0)
       aws-sdk-core (~> 3, >= 3.26.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-core (3.32.0)
+    aws-sdk-core (3.37.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)

--- a/lib/jekyll-cloudsearch/client.rb
+++ b/lib/jekyll-cloudsearch/client.rb
@@ -30,7 +30,7 @@ module Jekyll
       end
 
       def add_document(doc)
-        if doc.data.dig('search_excluded')
+        if doc.data.dig('search_excluded') || ! doc.collection.metadata.dig('output')
           @search_excluded_ids.push("CF_#{ENV['CONTENTFUL_SPACE_ID']}_#{doc.data.dig('id')}")
         else
           @docs.push({

--- a/lib/jekyll-cloudsearch/hook.rb
+++ b/lib/jekyll-cloudsearch/hook.rb
@@ -2,7 +2,7 @@ enabled = ARGV.include?('--cloudsearch')
 
 if enabled
   @client = Jekyll::Cloudsearch::Client.new
-  Jekyll::Hooks .register :documents, :post_render do |doc|
+  Jekyll::Hooks.register :documents, :post_render do |doc|
     @client.add_document(doc)
   end
 end

--- a/lib/jekyll-cloudsearch/hook.rb
+++ b/lib/jekyll-cloudsearch/hook.rb
@@ -1,9 +1,8 @@
 enabled = ARGV.include?('--cloudsearch')
 
 if enabled
-  @docs = []
   @client = Jekyll::Cloudsearch::Client.new
-  Jekyll::Hooks.register :documents, :post_render do |doc|
+  Jekyll::Hooks .register :documents, :post_render do |doc|
     @client.add_document(doc)
   end
 end

--- a/lib/jekyll-cloudsearch/version.rb
+++ b/lib/jekyll-cloudsearch/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Cloudsearch
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end

--- a/spec/dummy/_config.yml
+++ b/spec/dummy/_config.yml
@@ -1,0 +1,9 @@
+collections_dir: collections
+
+collections:
+  posts:
+    output: true
+    permalink: /:collection/:title
+    filename: "{{ published_at | date: '%Y-%m-%d' }}-{{ slug }}"
+  promos:
+    output: false

--- a/spec/dummy/collections/_promos/some-promo.md
+++ b/spec/dummy/collections/_promos/some-promo.md
@@ -1,0 +1,6 @@
+---
+id: My Great Promo
+title: Some Promo
+---
+
+This is content!

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -67,6 +67,23 @@ describe Jekyll::Cloudsearch::Client do
     expect(@client.search_excluded_ids.include?(doc_id)).to eq(true)
   end
 
+  context 'for collections with output=false' do
+
+    before do
+      @site.documents.each do |doc|
+        @client.add_document(doc)
+      end
+    end
+
+    it 'should exclude all docs' do
+      indexed_titles = @client.docs.collect{|d| d.dig(:fields, :title) }
+      @site.collections['promos'].collect(&:title).each do |title|
+        expect(indexed_titles).to_not include(title)
+      end
+    end
+
+  end
+
   it 'should write and upload' do
     allow(@client).to receive(:write)
     allow(@client).to receive(:upload)


### PR DESCRIPTION
## Problem 

Search should only return results with real output (pages). For example if you search for the promo - it will be found, but if you click on the link related to that search result  - you will be taken to the oops page

The other example if you search for "sign off" (currently - "Pretty words won’t change your life".) You will get link to Article Main among search results. Clicking on Article Main links takes you to oops page.

## Resolution

This PR updates the `jekyll-cloudsearch` to exclude any document that belongs to a collection marked `output: false` in Jekyll's config. Its my expectation the indexes themselves will be purged of bogus SERPs the next time this script runs. 
